### PR TITLE
Allow canceling sleep by clicking the background

### DIFF
--- a/DSx_Code_Files/DSx_functions.tcl
+++ b/DSx_Code_Files/DSx_functions.tcl
@@ -532,7 +532,7 @@ proc off_timer {} {
     set_next_page off DSx_power;
     page_show DSx_power;
 
-    after 3000 {set_next_page off off; set ::current_espresso_page "off"; start_sleep}
+    set ::DSx_sleep_timer [ after 3000 {set_next_page off off; set ::current_espresso_page "off"; start_sleep} ]
 }
 
 proc window_expand {} {

--- a/DSx_Code_Files/DSx_skin.tcl
+++ b/DSx_Code_Files/DSx_skin.tcl
@@ -594,6 +594,7 @@ if {[file exists "[skin_directory]/DSx_Home_Page/DSx_home.page"] == 1} {
 add_de1_text "sleep" 2500 1440 -justify right -anchor "ne" -text [translate "Going to sleep"] -font [DSx_font font 20] -fill $::DSx_settings(font_colour)
 add_de1_text "DSx_power" 1370 760 -justify left -anchor "ne" -text [translate "Power off  >>> "] -font [DSx_font font 16] -fill $::DSx_settings(font_colour)
 add_de1_text "DSx_power" 1600 1400 -justify center -anchor center -text [translate "...or wait for sleep"] -font [DSx_font font 16] -fill $::DSx_settings(font_colour)
+add_de1_button "DSx_power" {say [translate {awake}] $::settings(sound_button_in); after cancel $::DSx_sleep_timer; set_next_page off off; start_idle} 0 0 2560 1600
 add_de1_button "DSx_power" {say [translate {sleep}] $::settings(sound_button_in); set ::current_espresso_page "off"; power_off} 1400 700 1600 900
 add_de1_button "saver descaling cleaning" {say [translate {awake}] $::settings(sound_button_in); set_next_page off off; start_idle; clearshit} 1280 0 2560 1600
 add_de1_button "saver descaling cleaning" {say [translate {awake}] $::settings(sound_button_in); first_page_from_saver} 0 0 1280 1600


### PR DESCRIPTION
I often click the power button and then realise I forgot to flush (or similar). This patch allows me to abort the sleep by clicking anywhere on the power page that isn't the actual power off button.